### PR TITLE
Fix iOS accessibility announcement bug

### DIFF
--- a/Sources/CubeToast/ToastContainerView.swift
+++ b/Sources/CubeToast/ToastContainerView.swift
@@ -47,7 +47,9 @@ public final class ToastContainerView: UIView {
         hostingController = host
         layoutIfNeeded()
         
-        UIAccessibility.post(notification: .announcement, argument: toast.text)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            UIAccessibility.post(notification: .announcement, argument: toast.text)
+        }
         
         host.view.transform = CGAffineTransform(translationX: 0, y: host.view.bounds.height)
         host.view.alpha = 0

--- a/Sources/CubeToast/ToastModifier.swift
+++ b/Sources/CubeToast/ToastModifier.swift
@@ -26,7 +26,9 @@ struct ToastModifier: ViewModifier {
                 withAnimation(.bouncy(extraBounce: 0.2)) {
                     isPresented = true
                 }
-                AccessibilityNotification.Announcement(value.text).post()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    AccessibilityNotification.Announcement(value.text).post()
+                }
                 scheduleDismiss()
             } else if isPresented {
                 dismiss()


### PR DESCRIPTION
## What?

Added slight delay to make sure announcement is always made.


## Why?
[Reference 1](https://stackoverflow.com/questions/55522345/why-is-uiaccessibility-postnotification-announcement-argument-arg-not-an)
[Reference 2](https://medium.com/@rahgurung/why-we-sometimes-need-dispatch-delay-in-ios-for-proper-accessibility-focus-and-announcements-a58374ec8e4a)
