### PR TITLE
Fix toast persisting after view disappears

### DIFF
--- a/Sources/CubeToast/ToastModifier.swift
+++ b/Sources/CubeToast/ToastModifier.swift
@@ -40,6 +40,7 @@ struct ToastModifier: ViewModifier {
         }
         .onDisappear {
             dismissTimer?.cancel()
+            dismiss()
         }
     }
 


### PR DESCRIPTION
## What?

Dismiss the toast to fix an issue where it could persist if the main view disappeared before the dismiss timer fired.

## Why?

[iOS - Task Complete Issues (known issue)](https://3sidedcube.atlassian.net/browse/ARCEM-4532)
> Issue 1: Toast Persistence on Task Detail Navigation
> 
> Description: When a user checks off a task and the "Task Complete" toast notification appears, if the user immediately navigates to the task detail screen, the toast notification persists instead of disappearing.
> 
> Steps to Reproduce:
> 
> Navigate to the Prepare Tab > Plan > View all tasks
> 
> Check off a task.
> 
> Immediately tap on a task to view task details (>).
> 
> Expected Result: The "Task Complete" toast should disappear upon navigating to the task detail.
> 
> Actual Result: The toast notification remains visible on the task detail screen.

## Screen recording
|Before|After|
:-:|:-:
![RocketSim_Recording_iPhone_16_6 1_2025-12-19_18 37 48](https://github.com/user-attachments/assets/252b54cb-a473-4097-a3e8-a57539bdbb56)|![RocketSim_Recording_iPhone_16_6 1_2025-12-19_18 52 22](https://github.com/user-attachments/assets/7d9e6ed2-860f-4369-bf4d-93e2161ff861)